### PR TITLE
Fix typo in lunch_create docstring

### DIFF
--- a/pocho.py
+++ b/pocho.py
@@ -27,7 +27,7 @@ MESSAGES = {
 @willie.module.example('.lunch_create milanesas con pure')
 def lunch_create(bot, trigger):
     """
-    Set a lunch for today: .lunch_create <menu descrition>
+    Set a lunch for today: .lunch_create <menu description>
 
     """
     menu = trigger.group(2).strip()


### PR DESCRIPTION
The lunch_create docstring which is used for the command's help had a small typo (it said descrition instead of description), this pull request fixes that.
